### PR TITLE
AZhu - Add delete endpoint for UCSB Organizations

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
@@ -72,4 +72,16 @@ public class UCSBOrganizationsController extends ApiController {
         return organization;
     }
 
+    @Operation(summary= "Delete a UCSB Organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteCommons(
+            @Parameter(name="code") @RequestParam String code) {
+        UCSBOrganizations organization = ucsbOrganizationsRepository.findById(code)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganizations.class, code));
+
+        ucsbOrganizationsRepository.delete(organization);
+        return genericMessage("UCSB Organization with id %s deleted".formatted(code));
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
@@ -195,5 +195,54 @@ public class UCSBOrganizationsControllerTests extends ControllerTestCase {
             assertEquals("UCSBOrganizations with id DNE not found", json.get("message"));
         }
 
+    // Tests for DELETE /api/ucsbdiningcommons?...
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_delete_a_date() throws Exception {
+        // arrange
+
+        UCSBOrganizations sky = UCSBOrganizations.builder()
+                        .orgCode("SKY")
+                        .orgTranslation("SKYDIVINGCLUBATUCSB")
+                        .orgTranslationShort("SKYDIVINGCLUB")
+                        .inactive(false)
+                        .build();
+
+        when(ucsbOrganizationsRepository.findById(eq("SKY"))).thenReturn(Optional.of(sky));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        delete("/api/ucsborganizations?code=SKY")
+                                        .with(csrf()))
+                        .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationsRepository, times(1)).findById("SKY");
+        verify(ucsbOrganizationsRepository, times(1)).delete(any());
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSB Organization with id SKY deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existant_commons_and_gets_right_error_message()
+                throws Exception {
+        // arrange
+
+        when(ucsbOrganizationsRepository.findById(eq("SKY"))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        delete("/api/ucsborganizations?code=SKY")
+                                        .with(csrf()))
+                        .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationsRepository, times(1)).findById("SKY");
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("UCSBOrganizations with id SKY not found", json.get("message"));
+    }
 
 }


### PR DESCRIPTION
In this PR, we add the delete endpoint for UCSB Organizations, which allows admin users to delete an organizations based on orgCode. Also added the required tests and made sure that the user cannot delete an org that does not exist.

Dokku: https://team02-audoreven-dev.dokku-12.cs.ucsb.edu/

Closes #18 