### PR TITLE
AN - Added DELETE endpoint for a specific record in HelpRequest

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,7 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.HelpRequest;
-import edu.ucsb.cs156.example.entities.UCSBDate;
+
 import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
 
@@ -87,6 +87,18 @@ public class HelpRequestController extends ApiController {
                 .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
 
         return helpRequest;
+    }
+
+    @Operation(summary= "Delete a help request") //FIXME: implement
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteHelpRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        helpRequestRepository.delete(helpRequest);
+        return genericMessage("HelpRequest with id %s deleted".formatted(id));
     }
 
     

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -3,9 +3,7 @@ package edu.ucsb.cs156.example.controllers;
 import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import edu.ucsb.cs156.example.ControllerTestCase;
-import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.entities.HelpRequest;
-import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
 import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
 
 import java.util.ArrayList;
@@ -212,6 +210,60 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 assertEquals("EntityNotFoundException", json.get("type"));
                 assertEquals("HelpRequest with id 123 not found", json.get("message"));
         }
+
+         // Tests for DELETE /api/HelpRequest?id=123
+
+         @WithMockUser(roles = { "ADMIN", "USER" })
+         @Test
+         public void admin_can_delete_a_date() throws Exception {
+                 // arrange
+ 
+                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+ 
+                 HelpRequest helpRequest1 = HelpRequest.builder()
+                                 .requesterEmail("cgaucho@ucsb.edu")
+                                .teamId("s22-5pm-3")
+                                .tableOrBreakoutRoom("7")
+                                .requestTime(ldt1)
+                                .explanation("Need help with Swagger-ui")
+                                .solved(true)
+                                .build();
+ 
+                 when(helpRequestRepository.findById(eq(123L))).thenReturn(Optional.of(helpRequest1));
+ 
+                 // act
+                 MvcResult response = mockMvc.perform(
+                                 delete("/api/HelpRequest?id=123")
+                                                 .with(csrf()))
+                                 .andExpect(status().isOk()).andReturn();
+ 
+                 // assert
+                 verify(helpRequestRepository, times(1)).findById(123L);
+                 verify(helpRequestRepository, times(1)).delete(any());
+ 
+                 Map<String, Object> json = responseToJson(response);
+                 assertEquals("HelpRequest with id 123 deleted", json.get("message"));
+         }
+         
+         @WithMockUser(roles = { "ADMIN", "USER" })
+         @Test
+         public void admin_tries_to_delete_non_existant_helprequest_and_gets_right_error_message()
+                         throws Exception {
+                 // arrange
+ 
+                 when(helpRequestRepository.findById(eq(123L))).thenReturn(Optional.empty());
+ 
+                 // act
+                 MvcResult response = mockMvc.perform(
+                                 delete("/api/HelpRequest?id=123")
+                                                 .with(csrf()))
+                                 .andExpect(status().isNotFound()).andReturn();
+ 
+                 // assert
+                 verify(helpRequestRepository, times(1)).findById(123L);
+                 Map<String, Object> json = responseToJson(response);
+                 assertEquals("HelpRequest with id 123 not found", json.get("message"));
+         }
 
 
 


### PR DESCRIPTION
For this PR, I have worked on the HelpRequestController by adding the DELETE endpoint. I have also implemented tests for the endpoint. I have full Jacoco test coverage and pitest mutation coverage. I have also tested it locally and deployed it to dokku and it works. Meets all acceptance criteria on the Kanban board. Here's my dokku deployment:
link: https://team02-anisavic-dev.dokku-12.cs.ucsb.edu
Closes #36 